### PR TITLE
TCC-12231 Fix Oracle JDK7 issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 script: mvn clean install
 after_success:

--- a/src/test/resources/errors/is_raised_on_unexpected_error.yaml
+++ b/src/test/resources/errors/is_raised_on_unexpected_error.yaml
@@ -7,4 +7,4 @@ request:
     api_key: "ef0fd50fca1fb14c1fab3a8436b9ecb65f02f129fd87eafa45ded8ae257528f0"
   verb: "post"
   url: "http://localhost:5555/v2/authenticate/api"
-inner_error: "java.net.ConnectException: Connection refused"
+inner_error: "java.net.ConnectException: Connection refused (Connection refused)"


### PR DESCRIPTION
JDK 6 & 7 only available with an Oracle Support account (not free).
Updated BetaMax tape expected Java Connection Refused Error String.