### PR TITLE
Fixed failing javadoc generation for JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <source>8</source>
                     <additionalOptions>${javadoc.opts}</additionalOptions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Added a target of Java 8 into the javadoc configuration. Since the project is compiled against 1.8 anyway seems to make sense and allows the project to build Tested against 10 & 11 

Ref https://bugs.openjdk.java.net/browse/JDK-8212233?attachmentViewMode=list