### PR TITLE
Simplify join methods and add tests

### DIFF
--- a/src/main/java/com/currencycloud/client/Utils.java
+++ b/src/main/java/com/currencycloud/client/Utils.java
@@ -1,5 +1,7 @@
 package com.currencycloud.client;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public enum Utils {
@@ -22,18 +24,13 @@ public enum Utils {
     }
 
     public static String joinInverse(List<String> strings, String separator) {
-        if (strings == null) {
+        if (strings == null || separator == null) {
             return null;
         }
-        StringBuilder sb = new StringBuilder();
-        for (int i = strings.size() - 1; i >= 0; i--) {
-            String string = strings.get(i);
-            if (sb.length() > 0) {
-                sb.append(separator);
-            }
-            sb.append(string);
-        }
-        return sb.toString();
+
+        List<String> reversed = new ArrayList<>(strings);
+        Collections.reverse(reversed);
+        return String.join(separator, reversed);
     }
 
     public static Throwable getRootCause(Throwable t) {

--- a/src/main/java/com/currencycloud/client/Utils.java
+++ b/src/main/java/com/currencycloud/client/Utils.java
@@ -9,28 +9,25 @@ public enum Utils {
 
     public static final String dateFormat = "yyyy-MM-dd'T'HH:mm:ssX";
 
-    public static String join(Iterable<String> strings, String separator) {
-        if (strings == null) {
+    public static String join(List<String> strings, String separator) {
+        if (!validInput(strings, separator)) {
             return null;
         }
-        StringBuilder sb = new StringBuilder();
-        for (String string : strings) {
-            if (sb.length() > 0) {
-                sb.append(separator);
-            }
-            sb.append(string);
-        }
-        return sb.toString();
+        return String.join(separator, strings);
     }
 
     public static String joinInverse(List<String> strings, String separator) {
-        if (strings == null || separator == null) {
+        if (!validInput(strings, separator)) {
             return null;
         }
 
         List<String> reversed = new ArrayList<>(strings);
         Collections.reverse(reversed);
-        return String.join(separator, reversed);
+        return join(reversed, separator);
+    }
+
+    private static boolean validInput(List<String> strings, String separator) {
+        return strings != null && separator != null;
     }
 
     public static Throwable getRootCause(Throwable t) {

--- a/src/test/java/com/currencycloud/client/UtilsTest.java
+++ b/src/test/java/com/currencycloud/client/UtilsTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.assertThat;
 public class UtilsTest {
 
     private static final List<String> ANIMALS = Arrays.asList("elephant", "cow", "pig");
+    private static final String SEPARATOR = "|";
 
     @Test
     public void returnsRootCauseForChain() throws Exception {
@@ -31,21 +32,46 @@ public class UtilsTest {
     }
 
     @Test
+    public void join_validListAndSeparator_listInverted() {
+        String result = Utils.join(ANIMALS, SEPARATOR);
+        assertThat(result, is("elephant|cow|pig"));
+    }
+
+    @Test
+    public void join_singleItemInList_itemReturned() {
+        String item = "kangaroo";
+        String result = Utils.join(Collections.singletonList(item), SEPARATOR);
+        assertThat(result, is(item));
+    }
+
+    @Test
+    public void join_nullList_nullReturned() {
+        String result = Utils.join(null, SEPARATOR);
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void join_nullSeparator_nullReturned() {
+        String result = Utils.join(ANIMALS, null);
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
     public void joinInverse_validListAndSeparator_listInverted() {
-        String result = Utils.joinInverse(ANIMALS, "|");
+        String result = Utils.joinInverse(ANIMALS, SEPARATOR);
         assertThat(result, is("pig|cow|elephant"));
     }
 
     @Test
     public void joinInverse_singleItemInList_itemReturned() {
         String item = "kangaroo";
-        String result = Utils.joinInverse(Collections.singletonList(item), "|");
+        String result = Utils.joinInverse(Collections.singletonList(item), SEPARATOR);
         assertThat(result, is(item));
     }
 
     @Test
     public void joinInverse_nullList_nullReturned() {
-        String result = Utils.joinInverse(null, "|");
+        String result = Utils.joinInverse(null, SEPARATOR);
         assertThat(result, is(nullValue()));
     }
 

--- a/src/test/java/com/currencycloud/client/UtilsTest.java
+++ b/src/test/java/com/currencycloud/client/UtilsTest.java
@@ -2,10 +2,18 @@ package com.currencycloud.client;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 public class UtilsTest {
+
+    private static final List<String> ANIMALS = Arrays.asList("elephant", "cow", "pig");
 
     @Test
     public void returnsRootCauseForChain() throws Exception {
@@ -15,9 +23,35 @@ public class UtilsTest {
                 equalTo((Throwable) root)
         );
     }
+
     @Test
     public void returnsRootCauseForCauseless() throws Exception {
         RuntimeException e = new RuntimeException();
-        assertThat(Utils.getRootCause(e), equalTo((Throwable)e));
+        assertThat(Utils.getRootCause(e), equalTo((Throwable) e));
+    }
+
+    @Test
+    public void joinInverse_validListAndSeparator_listInverted() {
+        String result = Utils.joinInverse(ANIMALS, "|");
+        assertThat(result, is("pig|cow|elephant"));
+    }
+
+    @Test
+    public void joinInverse_singleItemInList_itemReturned() {
+        String item = "kangaroo";
+        String result = Utils.joinInverse(Collections.singletonList(item), "|");
+        assertThat(result, is(item));
+    }
+
+    @Test
+    public void joinInverse_nullList_nullReturned() {
+        String result = Utils.joinInverse(null, "|");
+        assertThat(result, is(nullValue()));
+    }
+
+    @Test
+    public void joinInverse_nullSeparator_nullReturned() {
+        String result = Utils.joinInverse(ANIMALS, null);
+        assertThat(result, is(nullValue()));
     }
 }


### PR DESCRIPTION
Add unit tests for helper method, and simplify the method.
Had to add check for separator not being present to avoid NullPointerException and added a unit test to cover this.