### PR TITLE
Make exception type a named field for YAML conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ When an error occurs in the API, the library is designed to provide as much info
 
 When the exception is logged, it will provide information such as the following:
 ```yaml
-BadRequestException
 ---
+exception_type: "BadRequestException"
 platform: Java 1.8.0_131 (Oracle Corporation)
 request:
   parameters:
@@ -141,13 +141,13 @@ errors:
 ```
 This is split into 5 sections:
 
-1. Error Type: In this case `BadRequestException` represents an HTTP 400 error
+1. Exception Type: In this case `BadRequestException` represents an HTTP 400 error
 2. Platform: The Java implementation that was used in the client
 3. Request: Details about the HTTP request that was made, e.g. the POST parameters
 4. Response: Details about the HTTP response that was returned, e.g. HTTP status code
 5. Errors: A list of errors that provide additional information
 
-The final section contains valuable information:
+The Errors section contains valuable information:
 
 - Field: The parameter that the error is linked to
 - Code: A code representing this error

--- a/src/main/java/com/currencycloud/client/exception/CurrencyCloudException.java
+++ b/src/main/java/com/currencycloud/client/exception/CurrencyCloudException.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * HTTP request and the server response. The {@link #toString()} method returns YAML-formatted data.
  */
 @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
-@JsonPropertyOrder({"platform", "request", "response", "errorCode", "errors"})
+@JsonPropertyOrder({"exceptionType", "platform", "request", "response", "errorCode", "errors"})
 public abstract class CurrencyCloudException extends RuntimeException {
 
     private static final Logger log = LoggerFactory.getLogger(ApiException.class);
@@ -47,12 +47,14 @@ public abstract class CurrencyCloudException extends RuntimeException {
     };
 
     private Request request;
+    private String exceptionType;
 
     protected CurrencyCloudException(String message, Throwable cause) {
         super(message, cause);
         if (cause instanceof InvocationAware) {
             setInvocation(((InvocationAware)cause).getInvocation());
         }
+        this.exceptionType = getClass().getSimpleName();
     }
 
     protected void setInvocation(@Nullable RestInvocation invocation) {
@@ -67,6 +69,13 @@ public abstract class CurrencyCloudException extends RuntimeException {
 
     public Request getRequest() {
         return request;
+    }
+
+    /**
+     * @return the root type of exception that was thrown
+     */
+    public String getExceptionType() {
+        return exceptionType;
     }
 
     /** @return The runtime environment of the client, eg. "Java 1.7" */
@@ -84,7 +93,6 @@ public abstract class CurrencyCloudException extends RuntimeException {
                 PrintWriter writer = new PrintWriter(out)
         ) {
             ObjectMapper mapper = new ObjectMapper(YAML_FACTORY);
-            writer.println(getClass().getSimpleName());
             mapper.setAnnotationIntrospector(IGNORE_EXCEPTION_PROPERTIES);
             mapper.writeValue(writer, this);
             return out.toString();

--- a/src/test/resources/errors/contains_full_details_for_api_error.yaml
+++ b/src/test/resources/errors/contains_full_details_for_api_error.yaml
@@ -1,5 +1,5 @@
-BadRequestException
 ---
+exception_type: "BadRequestException"
 platform: "${error.platform}"
 request:
   parameters:

--- a/src/test/resources/errors/is_raised_on_unexpected_error.yaml
+++ b/src/test/resources/errors/is_raised_on_unexpected_error.yaml
@@ -1,5 +1,5 @@
-UnexpectedException
 ---
+exception_type: "UnexpectedException"
 platform: "${error.platform}"
 request:
   parameters:


### PR DESCRIPTION
Currently, using the `toString()` method to retrieve the detail as to why the exception was thrown returns invalid YAML-formatted data due to the root exception type being added as an un-named field to the top of the data that is returned. When trying to marshal this via your YAML mapper of choice, this will fail.

This change adds the root exception type as `exception_type` to the YAML. The `README` and the two failing tests (that explicitly checked the pattern of of the `toString()` method via a file) have also been updated.

**Note: This is a breaking change, so considerations will need to be made.**