### PR TITLE
Payment validation

### DIFF
--- a/src/main/java/com/currencycloud/client/CurrencyCloud.java
+++ b/src/main/java/com/currencycloud/client/CurrencyCloud.java
@@ -720,6 +720,44 @@ public interface CurrencyCloud {
             @Nullable @FormParam("fee_currency") String feeCurrency
     ) throws ResponseException;
 
+    /** Validate a Payment */
+    @POST
+    @Path("payments/validate")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    PaymentValidationResult validatePayment(
+            @HeaderParam("X-Auth-Token") String authToken,
+            @HeaderParam("User-Agent") String userAgent,
+            @Nullable @HeaderParam("x-sca-force-sms") Boolean scaForceSms,
+            @FormParam("currency") String currency,
+            @FormParam("beneficiary_id") String beneficiaryId,
+            @FormParam("amount") BigDecimal amount,
+            @FormParam("reason") String reason,
+            @FormParam("reference") String reference,
+            @Nullable @FormParam("id") String paymentId,
+            @Nullable @FormParam("on_behalf_of") String onBehalfOf,
+            @Nullable @FormParam("payment_date") java.sql.Date paymentDate,
+            @Nullable @FormParam("payment_type") String paymentType,
+            @Nullable @FormParam("conversion_id") String conversionId,
+            @Nullable @FormParam("payer_entity_type") String payerEntityType,
+            @Nullable @FormParam("payer_company_name") String payerCompanyName,
+            @Nullable @FormParam("payer_first_name") String payerFirstName,
+            @Nullable @FormParam("payer_last_name") String payerLastName,
+            @Nullable @FormParam("payer_address") String payerAddress,
+            @Nullable @FormParam("payer_city") String payerCity,
+            @Nullable @FormParam("payer_country") String payerCountry,
+            @Nullable @FormParam("payer_postcode") String payerPostcode,
+            @Nullable @FormParam("payer_state_or_province") String payerStateOrProvince,
+            @Nullable @FormParam("payer_date_of_birth") java.sql.Date payerDateOfBirth,
+            @Nullable @FormParam("payer_identification_type") String payerIdentificationType,
+            @Nullable @FormParam("payer_identification_value") String payerIdentificationValue,
+            @Nullable @FormParam("unique_request_id") String uniqueRequestId,
+            @Nullable @FormParam("ultimate_beneficiary_name") String ultimateBeneficiaryName,
+            @Nullable @FormParam("purpose_code") String purposeCode,
+            @Nullable @FormParam("charge_type") String chargeType,
+            @Nullable @FormParam("fee_amount") BigDecimal feeAmount,
+            @Nullable @FormParam("fee_currency") String feeCurrency
+    ) throws ResponseException;
+
     /** Authorise a Payment */
     @POST
     @Path("payments/authorise")

--- a/src/main/java/com/currencycloud/client/CurrencyCloudClient.java
+++ b/src/main/java/com/currencycloud/client/CurrencyCloudClient.java
@@ -851,6 +851,45 @@ public class CurrencyCloudClient {
         );
     }
 
+    public PaymentValidationResult validatePayment(Payment payment, @Nullable Payer payer, @Nullable Boolean scaForceSms) throws CurrencyCloudException {
+        if (payer == null) {
+            payer = Payer.create();
+        }
+        return api.validatePayment(
+                authToken,
+                userAgent,
+                scaForceSms,
+                payment.getCurrency(),
+                payment.getBeneficiaryId(),
+                payment.getAmount(),
+                payment.getReason(),
+                payment.getReference(),
+                payment.getId(),
+                getOnBehalfOf(),
+                dateOnly(payment.getPaymentDate()),
+                payment.getPaymentType(),
+                payment.getConversionId(),
+                payer.getLegalEntityType(),
+                payer.getCompanyName(),
+                payer.getFirstName(),
+                payer.getLastName(),
+                flattenList(payer.getAddress()),
+                payer.getCity(),
+                payer.getCountry(),
+                payer.getPostcode(),
+                payer.getStateOrProvince(),
+                dateOnly(payer.getDateOfBirth()),
+                payer.getIdentificationType(),
+                payer.getIdentificationValue(),
+                payment.getUniqueRequestId(),
+                payment.getUltimateBeneficiaryName(),
+                payment.getPurposeCode(),
+                payment.getChargeType(),
+                payment.getFeeAmount(),
+                payment.getFeeCurrency()
+        );
+    }
+
     public PaymentAuthorisations authorisePayment(List<String> paymentIds) throws CurrencyCloudException {
          return api.authorisePayment(
                 authToken,

--- a/src/main/java/com/currencycloud/client/model/PaymentValidationResult.java
+++ b/src/main/java/com/currencycloud/client/model/PaymentValidationResult.java
@@ -1,0 +1,19 @@
+package com.currencycloud.client.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class PaymentValidationResult {
+    private String validationResult;
+
+    public String getValidationResult() {
+        return validationResult;
+    }
+
+    public void setValidationResult(String validationResult) {
+        this.validationResult = validationResult;
+    }
+}

--- a/src/test/java/com/currencycloud/client/PaymentsTest.java
+++ b/src/test/java/com/currencycloud/client/PaymentsTest.java
@@ -73,6 +73,23 @@ public class PaymentsTest extends BetamaxTestSupport {
     }
 
     @Test
+    @Betamax(tape = "can_validate", match = {MatchRule.method, MatchRule.uri, MatchRule.body})
+    public void testCanValidate() throws Exception {
+        Payment payment = Payment.create();
+        payment.setCurrency("EUR");
+        payment.setBeneficiaryId("60fbe8d3-f7d0-4124-9077-93d09fb2186a");
+        payment.setAmount(new BigDecimal("788.44"));
+        payment.setReason("Invoice");
+        payment.setReference("REF-INV-1838");
+        payment.setUniqueRequestId("a20bc586-b7a9-4316-9daf-d4ede4c0d3df");
+
+        PaymentValidationResult validationResult = client.validatePayment(payment, null, null);
+
+        assertThat(validationResult, notNullValue());
+        assertThat(validationResult.getValidationResult(), equalTo("success"));
+    }
+
+    @Test
     @Betamax(tape = "can_update", match = {MatchRule.method, MatchRule.uri, MatchRule.body})
     public void testCanUpdate() throws Exception {
         Payment payment = Payment.create();

--- a/src/test/java/com/currencycloud/client/http/DemoServerTest.java
+++ b/src/test/java/com/currencycloud/client/http/DemoServerTest.java
@@ -3,7 +3,6 @@ package com.currencycloud.client.http;
 import com.currencycloud.client.CurrencyCloudClient;
 import com.currencycloud.client.exception.ApiException;
 import com.currencycloud.client.exception.ForbiddenException;
-import com.currencycloud.client.exception.NotFoundException;
 import com.currencycloud.client.model.*;
 import com.currencycloud.examples.CurrencyCloudCookbook;
 import org.junit.Ignore;
@@ -15,6 +14,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -317,7 +318,7 @@ public class DemoServerTest {
         conversion.setBuyCurrency("EUR");
         conversion.setSellCurrency("GBP");
         conversion.setFixedSide("buy");
-        conversion.setAmount(new BigDecimal("10000.00"));
+        conversion.setAmount(new BigDecimal("20000.00"));
         conversion.setReason("Invoice Payment");
         conversion.setTermAgreement(true);
 
@@ -335,13 +336,16 @@ public class DemoServerTest {
         payerAddress.add("Payer Address Line 2");
         Payer payer = Payer.create(
                 "individual",
-                "Test Payer Company",
+                null,
                 "Test Payer First Name",
                 "Test Payer Last Name",
                 payerAddress,
                 "Paris",
                 "FR",
-                new Date());
+                Date.from(Instant.now().minus(2, ChronoUnit.DAYS)));
+        currencyCloud.validatePayment(payment, payer, null);
+        log.debug("Validated payment = {}", payment);
+
         payment = currencyCloud.createPayment(payment, payer);
         log.debug("Created payment = {}", payment);
 

--- a/src/test/resources/betamax/tapes/Payments/can_validate.yaml
+++ b/src/test/resources/betamax/tapes/Payments/can_validate.yaml
@@ -1,0 +1,29 @@
+name: can_validate
+interactions:
+- request:
+    method: POST
+    uri: http://localhost:5555/v2/payments/validate
+    body: currency=EUR&beneficiary_id=60fbe8d3-f7d0-4124-9077-93d09fb2186a&amount=788.44&reason=Invoice&reference=REF-INV-1838&unique_request_id=a20bc586-b7a9-4316-9daf-d4ede4c0d3df
+    headers:
+      X-Auth-Token:
+      - 6f5f99d1b860fc47e8a186e3dce0d3f9
+      User-Agent:
+      - CurrencyCloudSDK/2.0 Java/4.1.3
+  response:
+    status: 200
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 01 Jan 2018 12:34:56 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '852'
+      Connection:
+      - keep-alive
+      X-Request-Id:
+      - '2778807612227406608'
+      X-Content-Type-Options:
+      - nosniff
+    body: '{"validation_result":"success"}'


### PR DESCRIPTION
A PR with payment validation API endpoint integration.

API docs: https://www.currencycloud.com/developers/docs/item/validate-payment/
Note that docs say in description: 

> On success, returns an object that represents the payment that would be created if the payment create had been called.

This is not true though, as successful response returns the only one-field result as it is given later in docs.
`{
    "validation_result": "success"
}`

FYI: A lot of tests in DemoServerTest.java fail not related to the changes. I did some small value changes there because they forbid me from running tests successfully.
Also, `ReportingTest.testCanGeneratePaymentReport` fails when I have run it on localhost. It is because the `GregorianCalendar` is used on lines 72 and 73, and it changes days at a different timezone. Because of that, Betamax cannot match by the body of the request, as dates differ, and fails with tape in read_only mode.

