### PR TITLE
Upgrades the test scoped snakeyaml dependency to 1.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.32</version>
+            <version>1.33</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Cannot upgrade to snakeyaml 2.0 since there is a dependency on the deprecated betamax test library. However, since the snakeyaml is scoped to test only, there is no dependency on it in the production releases