### PR TITLE
WAL-3164: Remove "reason" as filter for transactions/find

### DIFF
--- a/src/main/java/com/currencycloud/client/CurrencyCloud.java
+++ b/src/main/java/com/currencycloud/client/CurrencyCloud.java
@@ -1468,7 +1468,7 @@ public interface CurrencyCloud {
       @Nullable @QueryParam("related_entity_short_reference") String relatedEntityShortReference,
       @Nullable @QueryParam("status") String status,
       @Nullable @QueryParam("type") String type,
-      @Nullable @QueryParam("reason") String reason,
+      @Deprecated @Nullable @QueryParam("reason") String reason,
       @Nullable @QueryParam("settles_at_from") java.sql.Date settlesAtFrom,
       @Nullable @QueryParam("settles_at_to") java.sql.Date settlesAtTo,
       @Nullable @QueryParam("created_at_from") java.sql.Date createdAtFrom,

--- a/src/main/java/com/currencycloud/client/CurrencyCloudClient.java
+++ b/src/main/java/com/currencycloud/client/CurrencyCloudClient.java
@@ -1437,7 +1437,7 @@ public class CurrencyCloudClient {
         transaction.getRelatedEntityShortReference(),
         transaction.getStatus(),
         transaction.getType(),
-        transaction.getReason(),
+        transaction.getReason(), /* Deprecated */
         dateOnly(transaction.getSettlesAtFrom()),
         dateOnly(transaction.getSettlesAtTo()),
         dateOnly(transaction.getCreatedAtFrom()),


### PR DESCRIPTION
Using "reason" as a filter for `transactions/find` has been deprecated.